### PR TITLE
Support additional args on the tailscale up command

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ release_stability: stable
 
 repo_description: Tailscale repository
 
+tailscale_args: ""
+
 apt_dependencies:
   - gnupg2
   - gnupg-agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: Bring Tailscale Up
   become: yes
-  command: tailscale up --authkey={{ tailscale_auth_key }}
+  command: tailscale up --authkey={{ tailscale_auth_key }} {{ tailscale_args }}
   # Since the auth key is included in this task, we do not want to log output
   # no_log: true
   register: tailscale_start


### PR DESCRIPTION
I'm using ansible to deploy tailscale relays into AWS and want to be able to do something like..

```
- name: Get AZ subnets
  ec2_vpc_subnet_facts:
    region: "{{ placement.region }}"
    filters:
      vpc-id: "{{ vpc_id }}"
      availability-zone: "{{ placement.availability_zone }}"
  register: subnet_info

- name: Set Subnet list
  set_fact:
    subnet_blocks: "{{ subnet_info.subnets | map(attribute='cidr_block') | list  }}"

- name: Configure Sysctl
  sysctl:
    name: net.ipv4.ip_forward=1
    value: 1
    state: present
    ignoreerrors: true
    sysctl_set: true

- name: Iptables Masquerade
  iptables:
    table: nat
    chain: POSTROUTING
    jump: MASQUERADE

- name: Configure Tailscale
  include_role:
    name: tailscale
  vars:
    tailscale_args: "-accept-routes=false -advertise-routes={{ subnet_blocks | join(',') }}"
```