### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # artis3n.tailscale
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/artis3n/ansible-role-tailscale/CI%20Tests)](https://github.com/artis3n/ansible-role-tailscale/actions)
 [![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/artis3n/ansible-role-tailscale?include_prereleases)](https://github.com/artis3n/ansible-role-tailscale/releases)
 ![GitHub last commit](https://img.shields.io/github/last-commit/artis3n/ansible-role-tailscale)
 ![GitHub](https://img.shields.io/github/license/artis3n/ansible-role-tailscale)


### PR DESCRIPTION
Can't separate `master` CI from failing PRs without adding additional triggers, so removing the badge. May add it back later.