### PR TITLE
Fix Galaxy meta for Arch

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,7 +31,7 @@ galaxy_info:
         - 31
     - name: ArchLinux
       versions:
-        - any
+        - all
 
   galaxy_tags:
     - tailscale


### PR DESCRIPTION
Amazon Linux 2 uses `versions: any` but Arch apparently needs `versions: all`. I love the standardization.