### PR TITLE
fix sysctl ip_forward example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Pass arbitrary command-line arguments:
 
     - name: Configure Sysctl
       sysctl:
-        name: net.ipv4.ip_forward=1
+        name: net.ipv4.ip_forward
         value: 1
         state: present
         ignoreerrors: true


### PR DESCRIPTION
As written previously, the line added to `/etc/sysctl.conf` is actually
```
net.ipv4.ip_forward=1=1
```
which is invalid