### PR TITLE
run tailscale up even when already connected

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,5 +81,4 @@
   register: tailscale_start
   when: >
     not tailscale_up_skip | bool
-    and '"hello.ipn.dev"' not in tailscale_status.stdout
   notify: Confirm Tailscale is Connected


### PR DESCRIPTION
We should always run `tailscale up` (unless `tailscale_up_skip`) in case we want to change the `tailscale_args` for an already connected machine.

If `tailscale_args` has not changed, it would be a no-op anyway.