### PR TITLE
Move cleanup from down to logout

### DIFF
--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -4,5 +4,5 @@
   tasks:
   - name: De-register Tailscale node
     become: true
-    command: tailscale down
+    command: tailscale logout
     changed_when: false


### PR DESCRIPTION
`logout` disconnects from Tailscale and expires the machine's key, whereas `down` only disconnects from Tailscale.