### PR TITLE
feat: adds OracleLinux support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,7 @@ yum_dependencies:
 yum_repos:
   Amazon: https://pkgs.tailscale.com/{{ release_stability | lower }}/amazon-linux/{{ ansible_distribution_major_version }}/tailscale.repo
   CentOS: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_distribution_major_version }}/tailscale.repo
+  OracleLinux: https://pkgs.tailscale.com/{{ release_stability | lower }}/centos/{{ ansible_distribution_major_version }}/tailscale.repo
 
 dnf_dependencies:
   - python-dnf
@@ -42,4 +43,4 @@ dnf_yum_dependencies:
 dnf_repos:
   Fedora: https://pkgs.tailscale.com/{{ release_stability | lower }}/fedora/tailscale.repo
 
-original_distribution_major_version: '{{ ansible_distribution_major_version }}'
+original_distribution_major_version: "{{ ansible_distribution_major_version }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,7 @@
         ansible_distribution == 'CentOS'
         or ansible_distribution == 'Amazon'
         or ansible_distribution == 'Fedora'
-
+        or ansible_distribution == 'OracleLinux'
     - name: Refresh Setup
       setup:
 
@@ -57,7 +57,7 @@
     msg: "{{ ansible_distribution }} {{ ansible_distribution_major_version }} ({{ ansible_distribution_release }})"
 
 - name: CentOS and related families
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Amazon'
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Amazon' or ansible_distribution == 'OracleLinux'
   include_tasks: centos.yml
 
 - name: Debian and related families


### PR DESCRIPTION
OracleLinux is a CentOS-based distribution, so detecting it as such.

Tested these changes on a couple of ARM-based instances with OracleLinux.