### PR TITLE
Fix Debian 11 failure with official release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: shellcheck
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v5.0.12
+    rev: v5.1.2
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -14,7 +14,7 @@
   become: true
   apt:
     name: "{{ legacy_apt_dependencies }}"
-  when: (ansible_distribution_major_version | int < 20) and ansible_distribution_major_version != "testing"
+  when: (ansible_distribution_major_version | int < 11) and ansible_distribution_major_version != "testing"
 
 - name: Debian | Tailscale Signing Key
   become: true


### PR DESCRIPTION
Debian 11 no longer requires python-apt (python2) and can use python3-apt like a regular distro.

Fixes #124