### PR TITLE
Fixed tailscale status returning exit code 1 when not logged in

### DIFF
--- a/molecule/skip-authentication/verify.yml
+++ b/molecule/skip-authentication/verify.yml
@@ -8,7 +8,7 @@
     changed_when: false
     register: tailscale_status
     failed_when:
-      - tailscale_status.rc != 0
+      - tailscale_status.rc not in [0, 1]
       - "'Logged out.' not in tailscale_status.stdout"
 
   - name: Assertions

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,7 +80,7 @@
   changed_when: false
   register: tailscale_status
   failed_when:
-    - tailscale_status.rc != 0
+    - tailscale_status.rc not in [0, 1]
     - "'Logged out.' not in tailscale_status.stdout"
 
 - name: Tailscale Status


### PR DESCRIPTION
Fixes https://github.com/artis3n/ansible-role-tailscale/issues/138