### PR TITLE
feat: only refresh the apt cache if it is stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Since Tailscale is still undergoing rapid development, we are holding off on cre
 Whether to output additional information during role execution.
 Helpful for debugging and collecting information to submit in a GitHub issue on this repository.
 
+### apt_cache_valid_time
+
+**Default**: `300`
+
+The age in seconds that the apt cache should be considered valid.
 ## Dependencies
 
 None

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,6 @@ force: false
 # Whether to use the stable or unstable upstream Tailscale build.
 # Strongly recommend to leave on 'stable' unless you know what you're doing
 release_stability: stable
+
+# age in seconds that the apt cache should be considered fresh enough
+apt_cache_valid_time: 300 # 5 min

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,14 +1,10 @@
 ---
-- name: Debian | Apt Update
-  become: true
-  apt:
-    update_cache: true
-
 - name: Debian | Apt Dependencies
   become: true
   apt:
     name: "{{ apt_dependencies }}"
     state: present
+    cache_valid_time: "{{ apt_cache_valid_time }}"
 
 - name: Debian | Legacy Apt Dependencies
   become: true
@@ -29,10 +25,11 @@
   apt_repository:
     repo: "{{ apt_deb }}"
     state: present
+  register: tailscale_apt_repo_result
 
 - name: Debian | Install Tailscale
   become: true
   apt:
     name: "{{ tailscale_package }}"
     state: latest
-    update_cache: true
+    update_cache: "{{ tailscale_apt_repo_result.changed }}"


### PR DESCRIPTION
This introduces a new role variable that allows people to set how long the apt-cache should remain valid for. Setting a high number allows for repeated use of this play without ansible reporting any changes.

If the age of the cache exceeds the configured value, the cache will be refreshed.