### PR TITLE
Make URL in error message clickable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
     msg: >
       You must include a Node Authorization auth key.
       Set a `tailscale_authkey` variable.
-      You can create this key from: https://login.tailscale.com/admin/authkeys.
+      You can create this key from: https://login.tailscale.com/admin/authkeys .
   when:
     - not tailscale_authkey or tailscale_authkey == None
     - not tailscale_up_skip | bool


### PR DESCRIPTION
Depending on the terminal/browser/os used, clicking on the link in the error message might lead you to an incorrect url (in my case, it was `https://login.tailscale.com/admin/authkeys./n`

Addind a space at the end of the error message should fix this reliably.