### PR TITLE
Fix quote of tailscale args

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -69,7 +69,7 @@
 
 - name: Install | Bring Tailscale Up
   become: true
-  ansible.builtin.command: tailscale up {{ tailscale_up_args | trim | quote }}
+  ansible.builtin.command: tailscale up {{ tailscale_up_args | trim }}
   # Since the auth key is included in this task's output, we do not want to log output
   no_log: "{{ not (insecurely_log_authkey | bool) }}"
   register: tailscale_start


### PR DESCRIPTION
Refs: https://github.com/artis3n/ansible-role-tailscale/issues/203

If `""` is added by `quote` keyword, the tailscale up command is `tailscale up "--authkey=FILTERED --advertise-exit-node=true"`. It is treated as `["tailscale", "up", "--authkey=FILTERED  --advertise-exit-node=true"]`, so the command will fail.

I remove the `quote` keyword to prevent this behavior.