### PR TITLE
Fix broken state after provisionning with an invalid auth key

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -44,6 +44,7 @@
   register: tailscale_status
   failed_when:
     - tailscale_status.rc != 0
+    - tailscale_status.rc != 1
     - "'Logged out.' not in tailscale_status.stdout"
 
 - name: Install | Tailscale Status
@@ -78,6 +79,7 @@
   when: >
     not tailscale_up_skip | bool
     and ('Logged out.' in tailscale_status.stdout
+    or tailscale_status.rc == 1
     or state_checksum != existing_state_checksum)
   notify: Confirm Tailscale is Connected
   async: 60


### PR DESCRIPTION
# Problem

The current test with `tailscale status` is too restrictive, and fails the task in situations where we can bring the system back up and running with `tailscale up`

# Reproduction steps

* Initially setup a node with this role and an auth key
* wait for the auth key and the node authorization to expire (6 months, I think)
* re-execute the role *without* first rotating the auth key
* the role execution fails, at the `tailscale up` step (which is normal, since the auth key is invalid)
* facepalm for forgetting to rotate the auth key, then rotate the auth key
* the role execution still fails, at the `tailscale status` step

This is due to the fact that in this state, `tailscale status` returns 1, with the following message : 
```
# Health check:
#     - not logged in, last login error=invalid key: API key XXXXXXXXXXXX not valid

unexpected state: NoState
```

# Untested simpler reproduction steps

* Initially setup a node with this role, with an invalid auth key
* It fails
* Rotate the auth key and retry

# Proposed fix

This MR proposes a basic fix, adding tolerance of the tailscale CLI returning 1.
It was tested on my own infrastructure, and worked there (Debian 11 servers, role version 3.4.0, ansible version 2.12.10).

It is however probably not production-grade code, as it lacks :
* documentation of the situations this is useful in
* molecule tests