### PR TITLE
Fix: Remove deprecated parameter 'warn' from command module invocation

### DIFF
--- a/tasks/fedora/install.yml
+++ b/tasks/fedora/install.yml
@@ -29,7 +29,6 @@
   ansible.builtin.command: dnf config-manager --add-repo {{ dnf_repos[ansible_distribution] }}
   args:
     creates: /etc/yum.repos.d/tailscale.repo
-    warn: false
 
 - name: Fedora | Install Tailscale
   become: true


### PR DESCRIPTION
Newer releases of Ansible (ansible-core 2.14.0 / Ansible 7) no longer support the warn parameter for the command module.

Executing the with the warn parameter present leads to task failure due to unsupported parameters for the command module.