### PR TITLE
fix: switch debian to use cache_valid_time

### DIFF
--- a/tasks/debian/install.yml
+++ b/tasks/debian/install.yml
@@ -1,13 +1,9 @@
 ---
-- name: Debian | Apt Update
-  become: true
-  ansible.builtin.apt:
-    update_cache: true
-
 - name: Debian | Apt Dependencies
   become: true
   ansible.builtin.apt:
     name: "{{ apt_dependencies }}"
+    cache_valid_time: 3600
     state: present
 
 - name: Debian | Legacy Apt Dependencies
@@ -37,5 +33,5 @@
   become: true
   ansible.builtin.apt:
     name: "{{ tailscale_package }}"
+    cache_valid_time: 3600
     state: '{{ state }}'
-    update_cache: true

--- a/tasks/debian/uninstall.yml
+++ b/tasks/debian/uninstall.yml
@@ -1,13 +1,9 @@
 ---
-- name: Debian | Apt Update
-  become: true
-  ansible.builtin.apt:
-    update_cache: true
-
 - name: Debian | Apt Dependencies
   become: true
   ansible.builtin.apt:
     name: "{{ apt_dependencies }}"
+    cache_valid_time: 3600
     state: present
 
 - name: Debian | Remove Tailscale

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,16 +39,11 @@
   # Only encountered on Debian so far during pre-release "testing" stage
   when: original_distribution_major_version == "NA"
   block:
-    - name: Apt Update
-      become: true
-      ansible.builtin.apt:
-        update_cache: true
-      when: ansible_distribution in debian_family_distros
-
     - name: Install lsb_release
       become: true
       ansible.builtin.package:
         name: lsb-release
+        cache_valid_time: 3600
         state: present
       when: ansible_distribution in debian_family_distros or ansible_distribution == 'ArchLinux'
 


### PR DESCRIPTION
There is already a a PR outstanding but missing a few more things.  FYI, `cache_valid_time` implies `update_cache`.