### PR TITLE
fix: remove legacy state if present and bypass ansible galaxy

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,3 @@
 collections:
-  - name: community.general
+  - name: https://github.com/ansible-collections/community.general
+    type: git

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,6 +19,11 @@
   when: ansible_distribution in tailscale_opensuse_family_distros
   ansible.builtin.include_tasks: opensuse/install.yml
 
+- name: Install | Remove legacy state folder
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.artis3n-tailscale"
+    state: absent
+
 - name: Install | Determine state folder
   ansible.builtin.set_fact:
     # Following https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html


### PR DESCRIPTION
We should remove the legacy state folder if it is present on the system.

Also, resolve <https://github.com/ansible/galaxy/issues/2302> by bypassing Ansible Galaxy and referencing `community.general` in CI by its git URL.
This will fix the ~60% chance of a CI test timing out to install the collection from Ansible Galaxy.

Closes #279 
