### PR TITLE
use geerlingguy amazonlinux2023 image

### DIFF
--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/artis3n/docker-amazonlinux2023-ansible:latest
+          - image: geerlingguy/docker-amazonlinux2023-ansible:latest
           - image: geerlingguy/docker-rockylinux8-ansible:latest
           - image: geerlingguy/docker-rockylinux9-ansible:latest
           - image: ghcr.io/artis3n/docker-almalinux8-ansible:latest


### PR DESCRIPTION
@geerlingguy made an Amazon Linux 2023 image and it updates on a schedule, so don't need to maintain my own anymore :) 