### PR TITLE
fix: correct galaxy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # artis3n.tailscale
 
-[![Ansible Role](https://img.shields.io/ansible/role/d/51664)](https://galaxy.ansible.com/artis3n/tailscale)
+[![Ansible Role](https://img.shields.io/ansible/role/d/3084)](https://galaxy.ansible.com/artis3n/tailscale)
 [![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/artis3n/ansible-role-tailscale?include_prereleases)](https://github.com/artis3n/ansible-role-tailscale/releases)
 [![Molecule Tests](https://github.com/artis3n/ansible-role-tailscale/actions/workflows/pull_request_target.yml/badge.svg)](https://github.com/artis3n/ansible-role-tailscale/actions/workflows/pull_request_target.yml)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6312/badge)](https://bestpractices.coreinfrastructure.org/projects/6312)


### PR DESCRIPTION
New Ansible Galaxy site changed their IDs: https://galaxy.ansible.com/api/v1/roles/.