### PR TITLE
feat: remove ubuntu 16.04 from supported distros

### DIFF
--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -61,8 +61,14 @@ jobs:
             command: /usr/lib/systemd/systemd
           - image: ghcr.io/artis3n/docker-amazonlinux2-ansible:latest
             command: /usr/lib/systemd/systemd
-          - image: geerlingguy/docker-ubuntu1604-ansible:latest
-            command: /lib/systemd/systemd
+          # Default version of Python in 16.04 is 3.5.2
+          # Ansible-core now requires 2.7 or 3.6 minimum.
+          #
+          # Therefore, while Tailscale supports Ubuntu 16.04,
+          # this role has deprecated support for it.
+          #
+          # - image: geerlingguy/docker-ubuntu1604-ansible:latest
+          #   command: /lib/systemd/systemd
 
     uses: ./.github/workflows/molecule.yml
     with:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
       versions:
         - eoan
         - bionic
-        - xenial
         - focal
         - groovy
         - hirsute


### PR DESCRIPTION
ansible-core 2.16.0 now requires Python 2.7 or 3.6 minimum.

Ubuntu 16.04's default version of Python3 is 3.5.2.

Therefore, while [Tailscale supports Ubuntu 16.04](https://tailscale.com/kb/1060/install-ubuntu-1604/), this role will deprecate support for it.

Closes #368 