### PR TITLE
bump the base devcontainer image

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,7 +5,6 @@ exclude_paths:
     - .vscode/
     - molecule/default/headscale.config.yaml
     - molecule/default/init_tailscale_vars.yml
-    - molecule/oauth/init_tailscale_vars.yml
 
 skip_list:
     - yaml[line-length]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,14 +16,9 @@
 		"ghcr.io/devcontainers-contrib/features/ansible:2": {},
 		"ghcr.io/devcontainers-contrib/features/poetry:2": {},
 		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
-		"ghcr.io/devcontainers/features/go:1": {},
 		"ghcr.io/devcontainers/features/common-utils:2": {
 			"installOhMyZsh": true,
 			"upgradePackages": true
-		},
-		"ghcr.io/devcontainers-contrib/features/zsh-plugins:0": {
-			"plugins": "zsh-syntax-highlighting",
-			"omzPlugins":"https://github.com/zsh-users/zsh-syntax-highlighting.git"
 		}
 	},
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: lint test
 # Install Python 3.10 first
 .PHONY: install
 install:
-	poetry install
+	poetry install --no-root
 	poetry run pre-commit install --install-hooks
 	poetry run ansible-galaxy collection install -r requirements.yml
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Ansible Role](https://img.shields.io/ansible/role/d/artis3n/tailscale)](https://galaxy.ansible.com/ui/standalone/roles/artis3n/tailscale/)
 [![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/artis3n/ansible-role-tailscale?include_prereleases)](https://github.com/artis3n/ansible-role-tailscale/releases)
 [![Molecule Tests](https://github.com/artis3n/ansible-role-tailscale/actions/workflows/pull_request_target.yml/badge.svg)](https://github.com/artis3n/ansible-role-tailscale/actions/workflows/pull_request_target.yml)
+[![Codespaces Prebuilds](https://github.com/artis3n/ansible-role-tailscale/actions/workflows/codespaces/create_codespaces_prebuilds/badge.svg)](https://github.com/artis3n/ansible-role-tailscale/actions/workflows/codespaces/create_codespaces_prebuilds)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6312/badge)](https://bestpractices.coreinfrastructure.org/projects/6312)
 ![GitHub last commit](https://img.shields.io/github/last-commit/artis3n/ansible-role-tailscale)
 ![GitHub](https://img.shields.io/github/license/artis3n/ansible-role-tailscale)

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -92,7 +92,7 @@
       {% else %}
       Unknown token format
       {% endif %}
-    tailscale_authkey_sting: >-
+    tailscale_authkey_string: >-
       {# Check if the key is an OAuth key #}
       {% if tailscale_authkey.startswith('tskey-client-') %}
       {{ tailscale_authkey }}?ephemeral={{ tailscale_oauth_ephemeral | bool }}&preauthorized={{ tailscale_oauth_preauthorized | bool }}
@@ -131,7 +131,7 @@
 
 - name: Install | Bring Tailscale Up
   become: true
-  ansible.builtin.command: "tailscale up {{ tailscale_args_string | trim }} --authkey={{ tailscale_authkey_sting | trim }}"
+  ansible.builtin.command: "tailscale up {{ tailscale_args_string | trim }} --authkey={{ tailscale_authkey_string | trim }}"
   # Since the auth key is included in this task's output, we do not want to log output
   no_log: "{{ not (insecurely_log_authkey | bool) }}"
   changed_when: true


### PR DESCRIPTION
Fixes the devcontainer environment which broke when we moved to python 3.12 in this repo: https://github.com/artis3n/ansible-role-tailscale/actions/runs/7792353009/job/21250173006#step:4:4434 .

Fixes typo of `tailscale_authkey_sting`.