### PR TITLE
[FIX] Improve decomission process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,14 @@ else
 	poetry run molecule test --scenario-name state-absent
 endif
 
+.PHONY: test-absent-purge
+test-absent-purge:
+ifndef TAILSCALE_CI_KEY
+	$(error TAILSCALE_CI_KEY is not set)
+else
+	poetry run molecule test --scenario-name state-absent-purge
+endif
+
 .PHONY: test-oauth
 test-oauth:
 ifndef TAILSCALE_OAUTH_CLIENT_SECRET

--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ Defines the timeout duration for the `tailscale up` command in seconds.
 Whether to output additional information during role execution.
 Helpful for debugging and collecting information to submit in a GitHub issue on this repository.
 
+### tailscale_purge_state
+
+**Default**: `false`
+
+Whether to delete the state directory created tailscale process: `/var/lib/tailscale`.
+
 # Dependencies
 
 ## Collections

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,6 @@ insecurely_log_authkey: false
 # Whether to store hashed authkey in state
 # Setting to false won't re-run 'tailscale up' on authkey change
 auth_key_in_state: true
+# Whether to purge state on uninstall
+# Setting to true will clean up the state folder /var/lib/tailscale
+tailscale_purge_state: false

--- a/molecule/state-absent-purge/converge.yml
+++ b/molecule/state-absent-purge/converge.yml
@@ -1,0 +1,33 @@
+---
+- name: Converge
+  hosts: instance
+  tasks:
+    - name: Init tailscale credentials variables
+      ansible.builtin.include_tasks: ../default/init_tailscale_vars.yml
+
+    - name: Install Tailscale
+      ansible.builtin.include_role:
+        name: artis3n.tailscale
+
+    # Force these to run before we start uninstalling things
+    - name: Flush Handlers
+      ansible.builtin.meta: flush_handlers
+
+    - name: Get Tailscale status
+      become: true
+      ansible.builtin.command: tailscale status
+      changed_when: false
+      register: tailscale_status
+
+    - name: Assert Tailscale is installed
+      ansible.builtin.assert:
+        that:
+          - "'Logged out.' not in tailscale_status.stdout"
+          - "'not logged in' not in tailscale_status.stdout"
+
+    - name: Uninstall Tailscale
+      ansible.builtin.include_role:
+        name: artis3n.tailscale
+      vars:
+        state: absent
+        tailscale_purge_state: true

--- a/molecule/state-absent-purge/molecule.yml
+++ b/molecule/state-absent-purge/molecule.yml
@@ -1,0 +1,46 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: ${MOLECULE_DISTRO:-geerlingguy/docker-ubuntu2204-ansible:latest}
+    command: ${MOLECULE_COMMAND:-/usr/sbin/init}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    docker_networks:
+      - name: headscale
+    networks:
+      - name: bridge
+      - name: headscale
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+  - name: headscale
+    image: ${HEADSCALE_IMAGE:-headscale/headscale:latest}
+    command: headscale serve
+    pre_build_image: true
+    networks:
+      - name: headscale
+    volumes:
+      - "${MOLECULE_PROJECT_DIRECTORY}/molecule/default/headscale.config.yaml:/etc/headscale/config.yaml"
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../default/prepare.yml
+verifier:
+  name: ansible
+scenario:
+  name: state-absent-purge
+  test_sequence:
+    - dependency
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/molecule/state-absent-purge/verify.yml
+++ b/molecule/state-absent-purge/verify.yml
@@ -1,0 +1,13 @@
+---
+- name: Verify
+  hosts: instance
+  tasks:
+    - name: Get state directory status
+      ansible.builtin.stat:
+        path: "/var/lib/tailscale"
+      register: ts_state_dir
+
+    - name: Assertions
+      ansible.builtin.assert:
+        that:
+          - not ts_state_dir.stat.exists

--- a/tasks/debian/uninstall.yml
+++ b/tasks/debian/uninstall.yml
@@ -11,6 +11,7 @@
   ansible.builtin.apt:
     name: "{{ tailscale_package }}"
     state: absent
+    purge: true
 
 - name: Debian | Remove Tailscale Deb
   become: true

--- a/tasks/debian/uninstall.yml
+++ b/tasks/debian/uninstall.yml
@@ -11,7 +11,7 @@
   ansible.builtin.apt:
     name: "{{ tailscale_package }}"
     state: absent
-    purge: true
+    purge: "{{ tailscale_purge_state | bool }}"
 
 - name: Debian | Remove Tailscale Deb
   become: true

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -16,6 +16,8 @@
     - tailscale_status.rc != 2
     # "bash: tailscale: command not found"
     - tailscale_status.rc != 127
+    # 500 Internal Server Error: invalid key: API key XXXXX not valid
+    - tailscale_status.rc != 1
 
 - name: Uninstall | Delete Tailscale State
   ansible.builtin.file:

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -16,8 +16,6 @@
     - tailscale_status.rc != 2
     # "bash: tailscale: command not found"
     - tailscale_status.rc != 127
-    # 500 Internal Server Error: invalid key: API key XXXXX not valid
-    - tailscale_status.rc != 1
 
 - name: Uninstall | Delete Tailscale State
   ansible.builtin.file:
@@ -58,3 +56,9 @@
 - name: Uninstall | OpenSUSE
   when: ansible_distribution in tailscale_opensuse_family_distros
   ansible.builtin.include_tasks: opensuse/uninstall.yml
+
+- name: Uninstall | Destroying Tailscale state
+  ansible.builtin.file:
+    path: "/var/lib/tailscale"
+    state: absent
+  when: tailscale_purge_state


### PR DESCRIPTION
Often, when I run the role with `state: absent`, the next role run with `state: present` will fail with different errors like described in the bug
https://github.com/artis3n/ansible-role-tailscale/issues/429

After talking to Tailscale support, that might happen if `/var/lib/tailscale/` still contains the previous machine identity (auth key, id, etc). 

We have to remove this folder during decommission.
Fortunately, Ubuntu package has that task inside the `tailscale.postrm`, (if the user rune `apt purge tailscale`):
```sh
$ cat /var/lib/dpkg/info/tailscale.postrm
#!/bin/sh
set -e
if [ -d /run/systemd/system ] ; then
	systemctl --system daemon-reload >/dev/null || true
fi

if [ -x "/usr/bin/deb-systemd-helper" ]; then
    if [ "$1" = "remove" ]; then
		deb-systemd-helper mask 'tailscaled.service' >/dev/null || true
	fi

    if [ "$1" = "purge" ]; then
		deb-systemd-helper purge 'tailscaled.service' >/dev/null || true
		deb-systemd-helper unmask 'tailscaled.service' >/dev/null || true
		rm -rf /var/lib/tailscale
	fi
fi
```
So, this is the best way to handle tailscale state removal - `purge: true,` because this will always be aligned with the package maintainers config.

I am not sure about other distros, though.
Probably, we need a task like this in each distro subtree:
```yaml
- name: Uninstall | Delete Tailscale Package State
  ansible.builtin.file:
    path: "/var/lib/tailscale"
    state: absent
```
@artis3n , please let me know how you prefer to handle this.

