### PR TITLE
fix: workaround ansible inconsistent var handling

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,8 +7,11 @@
 
 - name: Parse status JSON
   listen: Confirm Tailscale is Connected
-  vars:
+  ansible.builtin.set_fact:
     status: "{{ tailscale_status.stdout | from_json }}"
+
+- name: Set facts based on status
+  listen: Confirm Tailscale is Connected
   ansible.builtin.set_fact:
     tailscale_is_online: "{{ status.Self.Online }}"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,6 @@
 
 - name: Parse status JSON
   listen: Confirm Tailscale is Connected
-  listen: Confirm Tailscale is Connected
   ansible.builtin.set_fact:
     tailscale_is_online: "{{ (tailscale_status.stdout | from_json).Self.Online }}"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,13 +7,9 @@
 
 - name: Parse status JSON
   listen: Confirm Tailscale is Connected
-  ansible.builtin.set_fact:
-    status: "{{ tailscale_status.stdout | from_json }}"
-
-- name: Set facts based on status
   listen: Confirm Tailscale is Connected
   ansible.builtin.set_fact:
-    tailscale_is_online: "{{ status.Self.Online }}"
+    tailscale_is_online: "{{ (tailscale_status.stdout | from_json).Self.Online }}"
 
 - name: Tailscale online status
   listen: Confirm Tailscale is Connected

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -65,13 +65,11 @@
   register: tailscale_status
 
 - name: Install | Parse status JSON
+  vars:
+    tailscale_status_parsed: "{{ tailscale_status.stdout | from_json }}"
   ansible.builtin.set_fact:
-    status: "{{ tailscale_status.stdout | from_json }}"
-
-- name: Install | Set facts based on status
-  ansible.builtin.set_fact:
-    tailscale_is_online: "{{ status.Self.Online }}"
-    tailscale_version: "{{ status.Version }}"
+    tailscale_is_online: "{{  tailscale_status_parsed.Self.Online }}"
+    tailscale_version: "{{  tailscale_status_parsed.Version }}"
 
 - name: Install | Tailscale version and online status
   ansible.builtin.debug:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -65,8 +65,10 @@
   register: tailscale_status
 
 - name: Install | Parse status JSON
-  vars:
+  ansible.builtin.set_fact:
     status: "{{ tailscale_status.stdout | from_json }}"
+
+- name: Install | Set facts based on status
   ansible.builtin.set_fact:
     tailscale_is_online: "{{ status.Self.Online }}"
     tailscale_version: "{{ status.Version }}"


### PR DESCRIPTION
Context: if a variable is defined within a set_fact module call, and the variable value is used within the new varibles defined via set_fact. If the variable defined already has a value, within the set_fact variables the existing value will be used instead of the newly assigned value. Encounted with Ansible version 2.16.3

Reproduction example:

```yaml
- ansible.builtin.set_fact:
    status: "no a json"

- ansible.builtin.shell: >
     echo "{ \"Self\": { \"Online\": true }, \"Version\": 1.0 }"
  changed_when: false
  register: tailscale_status

- vars:
    status: "{{ tailscale_status.stdout | from_json }}" # <- does not take place
  ansible.builtin.set_fact:
    tailscale_is_online: "{{ status.Self.Online }}"
    tailscale_version: "{{ status.Version }}"
```

---

How I encountered the issue. In a project where the `devsec.hardening` collection -> `os_hardeding` role is used alongside this role, and that roles is included before this role. It defines it's own status variable which triggers a failure case in this role on the changed lines.

In some sense it looks like an unintentional behaviour that it works to use `vars` alongside `set_fact` as it's not listed as part of the attributes it supports https://docs.ansible.com/ansible/latest/collections/ansible/builtin/set_fact_module.html

The same behaviour is relied upon within the handlers, which I've also changed as it was triggering the error.

Upstream issue reported in Ansible https://github.com/ansible/ansible/issues/82698