### PR TITLE
[FIX] Improve decommission process_2

### DIFF
--- a/molecule/state-absent/verify.yml
+++ b/molecule/state-absent/verify.yml
@@ -13,7 +13,7 @@
         - tailscale_status.rc != 1
       register: tailscale_status
 
-    - name: Get state directory status
+    - name: Get idempotent state directory status
       ansible.builtin.stat:
         path: "{{ ansible_env.HOME }}/.artis3n-tailscale"
       register: state_dir
@@ -24,3 +24,13 @@
           - tailscale_status.rc == 1
           - not state_dir.stat.exists
           - "'tailscaled' not in ansible_facts.services or ansible_facts.services['tailscaled']['status'] == 'stopped'"
+
+    - name: Get tailscale package state directory status
+      ansible.builtin.stat:
+        path: "/var/lib/tailscale"
+      register: ts_state_dir
+
+    - name: Assertions
+      ansible.builtin.assert:
+        that:
+          - not ts_state_dir.stat.exists

--- a/molecule/state-absent/verify.yml
+++ b/molecule/state-absent/verify.yml
@@ -25,9 +25,9 @@
           - not state_dir.stat.exists
           - "'tailscaled' not in ansible_facts.services or ansible_facts.services['tailscaled']['status'] == 'stopped'"
 
-    - name: Get tailscale package state directory status
+    - name: Get tailscale package state file status
       ansible.builtin.stat:
-        path: "/var/lib/tailscale"
+        path: "/var/lib/tailscale/tailscaled.state"
       register: ts_state_dir
 
     - name: Assertions

--- a/tasks/debian/uninstall.yml
+++ b/tasks/debian/uninstall.yml
@@ -11,6 +11,7 @@
   ansible.builtin.apt:
     name: "{{ tailscale_package }}"
     state: absent
+    purge: true
 
 - name: Debian | Remove Tailscale Deb
   become: true

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -57,7 +57,7 @@
   when: ansible_distribution in tailscale_opensuse_family_distros
   ansible.builtin.include_tasks: opensuse/uninstall.yml
 
-- name: Uninstall | Destroying Tailscale state
+- name: Uninstall | Destroy Tailscale Package State
   ansible.builtin.file:
     path: "/var/lib/tailscale"
     state: absent

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -58,6 +58,7 @@
   ansible.builtin.include_tasks: opensuse/uninstall.yml
 
 - name: Uninstall | Destroy Tailscale Package State
+  become: true
   ansible.builtin.file:
     path: "/var/lib/tailscale/tailscaled.state"
     state: absent

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -56,3 +56,8 @@
 - name: Uninstall | OpenSUSE
   when: ansible_distribution in tailscale_opensuse_family_distros
   ansible.builtin.include_tasks: opensuse/uninstall.yml
+
+- name: Uninstall | Destroying Tailscale state
+  ansible.builtin.file:
+    path: "/var/lib/tailscale"
+    state: absent

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -59,5 +59,5 @@
 
 - name: Uninstall | Destroy Tailscale Package State
   ansible.builtin.file:
-    path: "/var/lib/tailscale"
+    path: "/var/lib/tailscale/tailscaled.state"
     state: absent


### PR DESCRIPTION
Often, when I run the role with `state: absent`, the next role run with `state: present` will fail with different errors. For example, like described in the bug
https://github.com/artis3n/ansible-role-tailscale/issues/429

After talking to Tailscale support, that issue might happen if `/var/lib/tailscale/` still contains the previous machine identity (state, auth key, id, etc). 

We have to remove this folder during decommission.
Fortunately, Ubuntu package has that task inside the `tailscale.postrm`, (if the user rune `apt purge tailscale`):
```sh
$ cat /var/lib/dpkg/info/tailscale.postrm
#!/bin/sh
set -e
if [ -d /run/systemd/system ] ; then
	systemctl --system daemon-reload >/dev/null || true
fi

if [ -x "/usr/bin/deb-systemd-helper" ]; then
    if [ "$1" = "remove" ]; then
		deb-systemd-helper mask 'tailscaled.service' >/dev/null || true
	fi

    if [ "$1" = "purge" ]; then
		deb-systemd-helper purge 'tailscaled.service' >/dev/null || true
		deb-systemd-helper unmask 'tailscaled.service' >/dev/null || true
		rm -rf /var/lib/tailscale
	fi
fi
```
So, this is the best way to handle tailscale state removal - `purge: true,` because this will always be aligned with the package maintainers config.

I am not sure about other distros, though.
Probably, we need a task like this in each distro subtree:
```yaml
- name: Uninstall | Delete Tailscale Package State
  ansible.builtin.file:
    path: "/var/lib/tailscale"
    state: absent
```
@artis3n , 
As we discussed here
https://github.com/artis3n/ansible-role-tailscale/pull/430#discussion_r1493393305
I removed variable from the code. 
Please let me know how do you prefer to handle this or if you need any help?


P.S. This is part of 
https://github.com/artis3n/ansible-role-tailscale/pull/430