### PR TITLE
update missing headscale temp env var

### DIFF
--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -14,6 +14,8 @@ env:
   # https://www.jeffgeerling.com/blog/2020/getting-colorized-output-molecule-and-ansible-on-github-actions-ci
   PY_COLORS: '1'
   ANSIBLE_FORCE_COLOR: '1'
+  # Temporary - https://github.com/artis3n/ansible-role-tailscale/issues/432#issuecomment-1948954799
+  HEADSCALE_IMAGE: headscale/headscale:0.22
 
 jobs:
   molecule:


### PR DESCRIPTION
There are headscale tests run directly from this workflow file instead of the `molecule.yml` reusable workflow, add the temp env var 