### PR TITLE
fix: align uninstall behavior across distros

### DIFF
--- a/tasks/debian/uninstall.yml
+++ b/tasks/debian/uninstall.yml
@@ -11,7 +11,6 @@
   ansible.builtin.apt:
     name: "{{ tailscale_package }}"
     state: absent
-    purge: true
 
 - name: Debian | Remove Tailscale Deb
   become: true

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -57,8 +57,8 @@
   when: ansible_distribution in tailscale_opensuse_family_distros
   ansible.builtin.include_tasks: opensuse/uninstall.yml
 
-- name: Uninstall | Destroy Tailscale Package State
+- name: Uninstall | Remove Tailscale Daemon State and Logs
   become: true
   ansible.builtin.file:
-    path: "/var/lib/tailscale/tailscaled.state"
+    path: "/var/lib/tailscale"
     state: absent


### PR DESCRIPTION
As a follow-up to #435, after further thought I'm removing the `purge` behavior from Debian since the other distros don't have similar behavior. Instead, removing the entire `/var/lib/tailscale` directory ourselves, so that behavior is preserved across all distros. This better aligns with <https://tailscale.com/kb/1069/uninstall?tab=linux> for each distro's uninstall command.
