### PR TITLE
Set filename to support auto update feature 

### DIFF
--- a/tasks/debian/install.yml
+++ b/tasks/debian/install.yml
@@ -27,6 +27,7 @@
   become: true
   ansible.builtin.apt_repository:
     repo: "{{ tailscale_apt_deb }}"
+    filename: "tailscale"
     state: present
 
 - name: Debian | Install Tailscale


### PR DESCRIPTION
The Tailscale client auto-update feature requires the sources list file in `/etc/apt/sources.list.d/tailscale.list` otherwise it won't work.