### PR TITLE
Fix redacting the auth key when tailscale up fails

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -167,6 +167,6 @@
 
 - name: Install | Report redacted failure from "tailscale up"  # noqa: no-handler
   ansible.builtin.fail:
-    msg: "{{ tailscale_start.stderr | default () | regex_replace('tskey.*\\s', 'REDACTED ') | regex_replace('\\t', '') | split('\n') }}"
+    msg: "{{ tailscale_start.stderr | default () | regex_replace(tailscale_authkey, 'REDACTED') | regex_replace('\\t', '') | split('\n') }}"
   when:
     - tailscale_start is failed


### PR DESCRIPTION
This patch redacts the authkey from `tailscale up` stderr output based on `tailscale_authkey` directly instead of the `tskey.*` regex. The same change was already applied for the stdout logging in #328 (see https://github.com/artis3n/ansible-role-tailscale/blob/7ebbe49a0413b8912c02bd9a81aa54a02538f6f5/tasks/install.yml#L150).