### PR TITLE
Add --reset to default tailscale up arguments

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -113,7 +113,7 @@
 
 - name: Install | Build the final tailscale_args
   ansible.builtin.set_fact:
-    tailscale_args_string: "{{ tailscale_args }} {{ tailscale_tags_string | trim }} --timeout={{ tailscale_up_timeout | trim }}s"
+    tailscale_args_string: "--reset {{ tailscale_args }} {{ tailscale_tags_string | trim }} --timeout={{ tailscale_up_timeout | trim }}s"
 
 - name: Install | Final `tailscale up` arguments string
   ansible.builtin.debug:


### PR DESCRIPTION
This patch adds `--reset` to the default `tailscale up` arguments which reset all non-default arguments to their defaults. This behavior matches what is documented in the README:

> Flags are not persisted between runs; you must specify all flags each
  time.

Fixes #455.