### PR TITLE
Run `tailscale status` in check mode

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -62,6 +62,8 @@
 - name: Install | Fetch Tailscale status
   ansible.builtin.command: tailscale status --json
   changed_when: false
+  # data gathering, not a change, so ok to run in check mode
+  check_mode: false
   register: tailscale_status
 
 - name: Install | Parse status JSON


### PR DESCRIPTION
The `tailscale status --json` command is purely gathering data (doesn't change anything), so it's ok to run in check mode.

https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_checkmode.html#enforcing-or-preventing-check-mode-on-tasks

From my testing, fixes #348 