### PR TITLE
feat: add node facts after role installation completes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# artis3n.tailscale
+# artis3n.tailscale  <!-- omit in toc -->
 
 [![Ansible Role](https://img.shields.io/ansible/role/d/artis3n/tailscale)](https://galaxy.ansible.com/ui/standalone/roles/artis3n/tailscale/)
 [![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/artis3n/ansible-role-tailscale?include_prereleases)](https://github.com/artis3n/ansible-role-tailscale/releases)
@@ -35,36 +35,53 @@ See the [CI worfklow](https://github.com/artis3n/ansible-role-tailscale/blob/mai
 > This role uses Ansible fully qualified collection names (FQCN) and therefore requires Ansible 2.11+.
 > Ansible 2.12 is set as the minimum required version as this was the version tested for compatibility during the FQCN refactor.
 
-# State Tracking
+- [Role Outputs](#role-outputs)
+- [Role Variables](#role-variables)
+  - [Required](#required)
+    - [tailscale\_authkey](#tailscale_authkey)
+    - [tailscale\_tags](#tailscale_tags)
+    - [tailscale\_up\_skip](#tailscale_up_skip)
+  - [Optional](#optional)
+    - [state](#state)
+    - [tailscale\_args](#tailscale_args)
+    - [tailscale\_oauth\_ephemeral](#tailscale_oauth_ephemeral)
+    - [tailscale\_oauth\_preauthorized](#tailscale_oauth_preauthorized)
+    - [insecurely\_log\_authkey](#insecurely_log_authkey)
+    - [release\_stability](#release_stability)
+    - [tailscale\_up\_timeout](#tailscale_up_timeout)
+    - [verbose](#verbose)
+- [Dependencies](#dependencies)
+  - [Collections](#collections)
+- [Example Playbook](#example-playbook)
+- [State Tracking](#state-tracking)
+- [License](#license)
+- [Author Information](#author-information)
+- [Development and Contributing](#development-and-contributing)
 
-This role will create an `artis3n-tailscale` directory in the target's [`XDG_STATE_HOME`](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) directory,
-or `$HOME/.local/state` if the variable is not present,
-in order to maintain a concept of state from the configuration of the arguments passed to `tailscale up`.
-This allows the role to idempotently update a Tailscale node's configuration when needed.
-Deleting this directory will lead to this role re-configuring Tailscale when it is not needed,
-but will not otherwise break anything.
-However, it is recommended that you let this Ansible role manage this directory and its contents.
-
-Note that:
-
-> Flags are not persisted between runs; you must specify all flags each time.
->
-> ...
->
-> In Tailscale v1.8 or later, if you forget to specify a flag you added before,
-> the CLI will warn you and provide a copyable command that includes all existing flags.
-
-<small>
-
-\- [docs: tailscale up][tailscale up docs]
-
-</small>
 
 This role will bubble up any stderr messages from the Tailscale binary
 to resolve any end-user configuration errors with `tailscale up` arguments.
 The `--authkey=` value will be redacted unless [`insecurely_log_authkey`](#insecurely_log_authkey) is set to `true`.
 
 ![logged stderr](docs/images/printed_stderr.png)
+
+# Role Outputs
+
+This role provides the IP v4 and v6 addresses of the Tailscale node as well as the output of `tailscale whois` against the node as facts.
+Several key pieces of `whois` information are provided directly, with the rest of the whois output stored as a JSON fact for your convenience.
+
+Outputted facts:
+
+```
+tailscale_node_ipv4           (string): The IPv4 address of the Tailscale node.
+tailscale_node_ipv6           (string): The IPv6 address of the Tailscale node.
+tailscale_node_hostname_full  (string): The full hostname (node.domain.ts.net) of the Tailscale node.
+tailscale_node_hostname_short (string): The short hostname (node) of the Tailscale node.
+tailscale_node_created_at     (string): The ISO-8601 timestamp the Tailscale node was created.
+tailscale_node_tags           (list):   The tags assigned to the Tailscale node.
+tailscale_node_services       (list):   The discovered services running on the Tailscale node.
+tailscale_node_whois          (dict):   The full output of `tailscale whois` against the Tailscale node.
+```
 
 # Role Variables
 
@@ -76,7 +93,7 @@ In most cases you will use `tailscale_authkey`.
 If you are uninstalling Tailscale (`state: absent`),
 neither `tailscale_authkey` nor `tailscale_up_skip` is required.
 
-If you are authenticating with an OAuth key, you must also set `tailscale_tags` (see below).
+If you are authenticating with an OAuth key, you must also set `tailscale_tags`.
 
 ### tailscale_authkey
 
@@ -90,7 +107,7 @@ A Node Authorization key can be generated under your Tailscale account. The role
 - OAuth key (`tskey-client-XXX-YYYY`) <https://login.tailscale.com/admin/settings/oauth>
 
 > [!IMPORTANT]
-> Using an OAuth key requires additionally setting the following variables:
+> Using an OAuth key requires the following role variables:
 > `tailscale_tags` (must be provided),
 > `tailscale_oauth_ephemeral` (defaults to `true`),
 > and `tailscale_oauth_preauthorized` (defaults to `false`).
@@ -106,6 +123,80 @@ If an OAuth key is used, be sure to grant the `write` Devices scope to the OAuth
 <img src="https://raw.githubusercontent.com/artis3n/ansible-role-tailscale/main/docs/images/oauth_scopes.png" alt="OAuth scopes" width="40%" height="40%">
 
 This value should be treated as a sensitive secret.
+
+### tailscale_tags
+
+**Default**: `[]`
+
+Apply supplied tags to the Tailscale nodes configured by this role
+(via the `--advertise-tags` flag to `tailscale up`).
+For more information, see [What are tags?](https://tailscale.com/kb/1068/acl-tags?q=acl%20tag#what-are-acl-tags)
+
+> [!NOTE]
+> Tags are required for OAuth clients (`tailscale_authkey` OAuth key).
+
+Entries should not include `tag:`.
+For example, `tailscale_tags: ['worker']` translates to `--advertise-tags=tag:worker`.
+
+### tailscale_up_skip
+
+**If set to true, `tailscale_authkey` is not required.**
+
+**Default**: `false`
+
+Whether to install and configure Tailscale as a service but skip running `tailscale up`.
+Helpful when packaging up a Tailscale installation into a build process, such as AMI creation,
+when the server should not yet authenticate to your Tailscale network.
+
+## Optional
+
+### state
+
+**Default**: `latest`
+
+Whether to install or uninstall Tailscale.
+If defined, `state` must be either `latest`, `present`, or `absent`.
+
+This role uses `latest` by default to help ensure your software remains up-to-date
+and incorporates the latest security and product features.
+For users who desire more control over configuration drift,
+`present` will not update Tailscale if it is already installed.
+
+Changes to [`tailscale_args`](#tailscale_args) will be applied under both `latest` and `present`;
+this parameter only impacts the version of Tailscale installed to the target system.
+
+If set to `absent`, this role will de-register the Tailscale node (if already authenticated)
+and clean up or disable all Tailscale artifacts added to the system.
+
+Note that neither `tailscale_authkey` nor `tailscale_up_skip` is required if `state` is set to `absent`.
+
+### tailscale_args
+
+Pass command-line arguments to `tailscale up`.
+
+Note that the [command][ansible.builtin.command] module is used,
+which does not support subshell expressions (`$()`) or bash operations like `;` and `&`.
+Only `tailscale up` arguments can be passed in.
+
+> [!CAUTION]
+> **Do not use this for `--authkey`.**
+> Use the `tailscale_authkey` variable instead.
+>
+> **Do not use this for `--advertise-tags`.**
+> Use the `tailscale_tags` variable instead.
+>
+> **Do not use this for `--timeout`.**
+> Use the `tailscale_up_timeout` variable instead.
+
+Any stdout/stderr output from the `tailscale` binary will be printed.
+Since the tasks move quickly in this section, a 5 second pause is introduced
+to grant more time for users to realize a message was printed.
+
+![printed stdout](docs/images/printed_stdout.png)
+
+Stderrs will continue to fail the role's execution.
+The sensitive `--authkey` value will be redacted by default.
+If you need to view the unredacted value, see [`insecurely_log_authkey`](#insecurely_log_authkey).
 
 ### tailscale_oauth_ephemeral
 
@@ -124,34 +215,6 @@ Register as an [ephemeral node](https://tailscale.com/kb/1111/ephemeral-nodes), 
 **Default**: `false`
 
 Skip [manual device approval](https://tailscale.com/kb/1099/device-approval), if `true`.
-
-### tailscale_tags
-
-**Default**: `[]`
-
-Apply supplied tags to the Tailscale nodes configured by this role
-(via the `--advertise-tags` flag to `tailscale up`).
-For more information, see [What are tags?](https://tailscale.com/kb/1068/acl-tags?q=acl%20tag#what-are-acl-tags)
-
-> [!NOTE]
-> Tags are required for OAuth clients (`tailscale_authkey` OAuth key).
-
-Entries should not include `tag:`.
-For example, `tailscale_tags: ['worker']` translates to `--advertise-tags=tag:worker`.
-
-> Auth keys generated by this OAuth client must assign tags (or tags managed by these tags) to devices they authorize.
-
-### tailscale_up_skip
-
-**If set to true, `tailscale_authkey` is not required.**
-
-**Default**: `false`
-
-Whether to install and configure Tailscale as a service but skip running `tailscale up`.
-Helpful when packaging up a Tailscale installation into a build process, such as AMI creation,
-when the server should not yet authenticate to your Tailscale network.
-
-## Optional
 
 ### insecurely_log_authkey
 
@@ -185,53 +248,6 @@ Whether to use the Tailscale stable or unstable track.
 `unstable`:
 
 > The bleeding edge. Pushed early and often. Expect rough edges!
-
-### state
-
-**Default**: `latest`
-
-Whether to install or uninstall Tailscale.
-If defined, `state` must be either `latest`, `present`, or `absent`.
-
-This role uses `latest` by default to help ensure your software remains up-to-date
-and incorporates the latest security and product features.
-For users who desire more control over configuration drift,
-`present` will not update Tailscale if it is already installed.
-Changes to [`tailscale_args`](#tailscale_args) will be applied under both `latest` and `present`;
-this parameter only impacts the version of Tailscale installed to the target system.
-
-If set to `absent`, this role will de-register the Tailscale node (if already authenticated)
-and clean up or disable all Tailscale artifacts added to the system.
-
-Note that neither `tailscale_authkey` nor `tailscale_up_skip` is required if `state` is set to `absent`.
-
-### tailscale_args
-
-Pass any additional command-line arguments to `tailscale up`.
-
-Note that the [command][ansible.builtin.command] module is used,
-which does not support subshell expressions (`$()`) or bash operations like `;` and `&`.
-Only `tailscale up` arguments can be passed in.
-
-> [!CAUTION]
-> **Do not use this for `--authkey`.**
-> Use the `tailscale_authkey` variable instead.
->
-> **Do not use this for `--advertise-tags`.**
-> Use the `tailscale_tags` variable instead.
->
-> **Do not use this for `--timeout`.**
-> Use the `tailscale_up_timeout` variable instead.
-
-Any stdout/stderr output from the `tailscale` binary will be printed.
-Since the tasks move quickly in this section, a 5 second pause is introduced
-to grant more time for users to realize a message was printed.
-
-![printed stdout](docs/images/printed_stdout.png)
-
-Stderrs will continue to fail the role's execution.
-The sensitive `--authkey` value will be redacted by default.
-If you need to view the unredacted value, see [`insecurely_log_authkey`](#insecurely_log_authkey).
 
 ### tailscale_up_timeout
 
@@ -346,6 +362,31 @@ De-register and uninstall a Tailscale node:
         state: absent
 ```
 
+# State Tracking
+
+This role will create an `artis3n-tailscale` directory in the target's [`XDG_STATE_HOME`](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) directory,
+or `$HOME/.local/state` if the variable is not present,
+in order to maintain a concept of state from the configuration of the arguments passed to `tailscale up`.
+This allows the role to idempotently update a Tailscale node's configuration when needed.
+Deleting this directory will lead to this role re-configuring Tailscale when it is not needed,
+but will not otherwise break anything.
+However, it is recommended that you let this Ansible role manage this directory and its contents.
+
+Note that:
+
+> Flags are not persisted between runs; you must specify all flags each time.
+>
+> ...
+>
+> In Tailscale v1.8 or later, if you forget to specify a flag you added before,
+> the CLI will warn you and provide a copyable command that includes all existing flags.
+
+<small>
+
+\- [docs: tailscale up][tailscale up docs]
+
+</small>
+
 # License
 
 MIT
@@ -359,18 +400,18 @@ Ari Kalfus ([@artis3n](https://www.artis3nal.com/)) <dev@artis3nal.com>
 This GitHub repository uses a dedicated "test" Tailscale account to authenticate Tailscale during CI runs.
 Each Docker container creates a new authorized machine in that test account.
 The machines are authorized with [ephemeral auth keys][]
-and are automatically cleaned up within 30 minutes-48 hours.
+and are automatically cleaned up.
 
-This value is stored in a [GitHub Action secret][] with the name `TAILSCALE_CI_KEY`.
+This authkey is stored in a [GitHub Action secret][] with the name `TAILSCALE_CI_KEY`.
 To test OAuth authkey compatibility, a Tailscale OAuth client secret is stored as `TAILSCALE_OAUTH_CLIENT_SECRET`.
 If you are a Collaborator on this repository,
-you can open a GitHub CodeSpace and these secrets will be pre-populated for you into the environment.
+you can open a GitHub CodeSpace and these secrets will be pre-populated for you in the environment.
 
 To test this role locally, store the Tailscale ephemeral auth key in a `TAILSCALE_CI_KEY` env var
 and, if running the `oauth` Molecule scenario,
-add an OAuth client secret in a `TAILSCALE_CI_KEY` env var.
+add an OAuth client secret in a `TAILSCALE_OAUTH_CLIENT_SECRET` env var.
 
-Alternatively for Molecule testing,
+Alternatively for [Molecule][] testing,
 you can use a [Headscale][] container that is spun up as part of the create/prepare steps.
 To do this, set a `USE_HEADSCALE` env variable.
 For example:
@@ -382,6 +423,7 @@ USE_HEADSCALE=true molecule test
 [ansible.builtin.command]: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/command_module.html
 [ephemeral auth keys]: https://tailscale.com/kb/1111/ephemeral-nodes/
 [github action secret]: https://docs.github.com/en/actions/reference/encrypted-secrets
+[molecule]: https://ansible.readthedocs.io/projects/molecule/
 [tailscale]: https://tailscale.com/
 [tailscale up docs]: https://tailscale.com/kb/1080/cli/#up
 [headscale]: https://github.com/juanfont/headscale/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "artis3n.tailscale"
-version = "4.4.4"
+version = "4.5.0"
 description = "Ansible role to install and enable a Tailscale node."
 authors = ["Artis3n <dev@artis3nal.com>"]
 license = "MIT"

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -11,7 +11,7 @@
   register: tailscale_ipv6_cmd
   changed_when: false
 
-- name: Facts | Register IP Facts
+- name: Facts | Register IP facts
   ansible.builtin.set_fact:
     tailscale_node_ipv4: "{{ tailscale_ipv4_cmd.stdout }}"
     tailscale_node_ipv6: "{{ tailscale_ipv6_cmd.stdout }}"

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -1,0 +1,48 @@
+---
+- name: Facts | Get IPv4 address
+  ansible.builtin.command:
+    cmd: tailscale ip --4
+  register: tailscale_ipv4_cmd
+  changed_when: false
+
+- name: Facts | Get IPv6 address
+  ansible.builtin.command:
+    cmd: tailscale ip --6
+  register: tailscale_ipv6_cmd
+  changed_when: false
+
+- name: Facts | Register IP Facts
+  ansible.builtin.set_fact:
+    tailscale_node_ipv4: "{{ tailscale_ipv4_cmd.stdout }}"
+    tailscale_node_ipv6: "{{ tailscale_ipv6_cmd.stdout }}"
+
+- name: Facts | Get Tailscale host facts
+  ansible.builtin.command:
+    cmd: tailscale whois --json {{ tailscale_node_ipv4 }}
+  register: tailscale_whois_cmd
+  changed_when: false
+
+- name: Facts | Parse Tailscale host information
+  ansible.builtin.set_fact:
+    tailscale_whois: "{{ tailscale_whois_cmd.stdout | from_json }}"
+
+- name: Facts | Set Tailscale host facts
+  ansible.builtin.set_fact:
+    tailscale_node_hostname_full: "{{ tailscale_whois.Node.Name }}"
+    tailscale_node_hostname_short: "{{ tailscale_whois.Node.Hostinfo.Hostname }}"
+    tailscale_node_created_at: "{{ tailscale_whois.Node.Created }}"
+    tailscale_node_services: "{{ tailscale_whois.Node.Hostinfo.Services }}"
+    tailscale_node_tags: "{{ tailscale_whois.Node.Tags }}"
+    tailscale_node_whois: "{{ tailscale_whois.Node }}"
+
+- name: Facts | Display key facts
+  ansible.builtin.debug:
+    msg: "{{ item }}"
+  when: verbose
+  loop:
+    - tailscale_node_hostname_full
+    - tailscale_node_hostname_short
+    - tailscale_node_created_at
+    - tailscale_node_ipv4
+    - tailscale_node_ipv6
+    - tailscale_node_tags

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -31,13 +31,13 @@
     tailscale_node_hostname_full: "{{ tailscale_whois.Node.Name }}"
     tailscale_node_hostname_short: "{{ tailscale_whois.Node.Hostinfo.Hostname }}"
     tailscale_node_created_at: "{{ tailscale_whois.Node.Created }}"
-    tailscale_node_services: "{{ tailscale_whois.Node.Hostinfo.Services }}"
-    tailscale_node_tags: "{{ tailscale_whois.Node.Tags }}"
+    tailscale_node_services: "{{ tailscale_whois.Node.Hostinfo.Services | default([]) }}"
+    tailscale_node_tags: "{{ tailscale_whois.Node.Tags | default([]) }}"
     tailscale_node_whois: "{{ tailscale_whois.Node }}"
 
 - name: Facts | Display key facts
   ansible.builtin.debug:
-    msg: "{{ item }}"
+    var: "{{ item }}"
   when: verbose
   loop:
     - tailscale_node_hostname_full

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -171,7 +171,7 @@
   when:
     - tailscale_start is failed
 
-- name: Install | Register Role Fact Outputs
+- name: Install | Register role facts
   ansible.builtin.include_tasks: facts.yml
   when:
     - not tailscale_up_skip

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -173,3 +173,5 @@
 
 - name: Install | Register Role Fact Outputs
   ansible.builtin.include_tasks: facts.yml
+  when:
+    - not tailscale_up_skip

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -170,3 +170,6 @@
     msg: "{{ tailscale_start.stderr | default () | regex_replace(tailscale_authkey, 'REDACTED') | regex_replace('\\t', '') | split('\n') }}"
   when:
     - tailscale_start is failed
+
+- name: Install | Register Role Fact Outputs
+  ansible.builtin.include_tasks: facts.yml


### PR DESCRIPTION
This PR adds new facts about the node after this role successfully installs Tailscale on that node.

See the updated README for details.

Closes #462
