### PR TITLE
Add FreeBSD as targeted platform

### DIFF
--- a/tasks/freebsd/install.yml
+++ b/tasks/freebsd/install.yml
@@ -1,0 +1,6 @@
+---
+- name: "FreeBSD | Install Tailscale"
+  become: true
+  community.general.pkgng:
+    name: "{{ tailscale_package }}"
+    state: "{{ state }}"

--- a/tasks/freebsd/uninstall.yml
+++ b/tasks/freebsd/uninstall.yml
@@ -1,0 +1,6 @@
+---
+- name: "FreeBSD | Uninstall Tailscale"
+  become: true
+  community.general.pkgng:
+    name: "{{ tailscale_package }}"
+    state: "absent"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,6 +23,10 @@
   when: ansible_distribution in tailscale_opensuse_family_distros
   ansible.builtin.include_tasks: opensuse/install.yml
 
+- name: Install | FreeBSD
+  when: ansible_distribution == 'FreeBSD'
+  ansible.builtin.include_tasks: freebsd/install.yml
+
 - name: Install | Remove legacy state folder
   ansible.builtin.file:
     path: "{{ ansible_env.HOME }}/.artis3n-tailscale"
@@ -39,7 +43,7 @@
     state: directory
     owner: "{{ ansible_user_uid }}"
     group: "{{ ansible_user_gid }}"
-    mode: '0700'
+    mode: "0700"
   loop:
     - "{{ tailscale_state_folder }}"
     - "{{ tailscale_state_folder }}/artis3n-tailscale"
@@ -50,7 +54,7 @@
     dest: "{{ tailscale_state_folder }}/artis3n-tailscale/README.md"
     owner: "{{ ansible_user_uid }}"
     group: "{{ ansible_user_gid }}"
-    mode: '0644'
+    mode: "0644"
 
 - name: Install | Enable Service
   become: true
@@ -126,7 +130,7 @@
     dest: "{{ tailscale_state_folder }}/artis3n-tailscale/state"
     owner: "{{ ansible_user_uid }}"
     group: "{{ ansible_user_gid }}"
-    mode: '0644'
+    mode: "0644"
   register: state_file
 
 - name: Install | Bring Tailscale Up
@@ -145,7 +149,7 @@
   async: "{{ (tailscale_up_timeout | trim | int) + 10 }}"
   poll: 5
 
-- name: Install | Report non-sensitive stdout from "tailscale up"  # noqa: no-handler
+- name: Install | Report non-sensitive stdout from "tailscale up" # noqa: no-handler
   ansible.builtin.debug:
     msg: "{{ tailscale_start.stdout | replace(tailscale_authkey, 'REDACTED') | regex_replace('\\t', '') | split('\n') }}"
   when:
@@ -165,7 +169,7 @@
   when:
     - tailscale_start is failed
 
-- name: Install | Report redacted failure from "tailscale up"  # noqa: no-handler
+- name: Install | Report redacted failure from "tailscale up" # noqa: no-handler
   ansible.builtin.fail:
     msg: "{{ tailscale_start.stderr | default () | regex_replace(tailscale_authkey, 'REDACTED') | regex_replace('\\t', '') | split('\n') }}"
   when:

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -57,6 +57,10 @@
   when: ansible_distribution in tailscale_opensuse_family_distros
   ansible.builtin.include_tasks: opensuse/uninstall.yml
 
+- name: Uninstall | FreeBSD
+  when: ansible_distribution == 'FreeBSD'
+  ansible.builtin.include_tasks: freebsd/uninstall.yml
+
 - name: Uninstall | Remove Tailscale Daemon State and Logs
   become: true
   ansible.builtin.file:


### PR DESCRIPTION
- [x] Installs successfully on FreeBSD
- [ ] Uninstalls successfully on FreeBSD
- [ ] CI wired up for FreeBSD
- [ ] Anything else?

Targeting FreeBSD 14 and newer, via pkgng.

Installing currently works fine from scratch.

Uninstalling fails in "Uninstall | Disable Tailscale Service" when evaluating `when: tailscale_service in ansible_facts.services` even though `ansible.builtin.service` is correctly managing services on FreeBSD from what I can tell.