### PR TITLE
Fix templating of tailscale_args_string if tailscale_tags is an empty list

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -73,8 +73,8 @@
   vars:
     tailscale_status_parsed: "{{ tailscale_status.stdout | from_json }}"
   ansible.builtin.set_fact:
-    tailscale_is_online: "{{  tailscale_status_parsed.Self.Online }}"
-    tailscale_version: "{{  tailscale_status_parsed.Version }}"
+    tailscale_is_online: "{{ tailscale_status_parsed.Self.Online }}"
+    tailscale_version: "{{ tailscale_status_parsed.Version }}"
 
 - name: Install | Tailscale version and online status
   ansible.builtin.debug:
@@ -118,7 +118,10 @@
 
 - name: Install | Build the final tailscale_args
   ansible.builtin.set_fact:
-    tailscale_args_string: "{{ tailscale_args }} {{ tailscale_tags_string | trim if tailscale_tags_string is not none else '' }} --timeout={{ tailscale_up_timeout | trim }}s"
+    tailscale_args_string: >
+      {{ tailscale_args }}
+      {{ tailscale_tags_string | trim if tailscale_tags_string is not none else '' }}
+      --timeout={{ tailscale_up_timeout | trim }}s
 
 - name: Install | Final `tailscale up` arguments string
   ansible.builtin.debug:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -118,7 +118,7 @@
 
 - name: Install | Build the final tailscale_args
   ansible.builtin.set_fact:
-    tailscale_args_string: "{{ tailscale_args }} {{ tailscale_tags_string | trim }} --timeout={{ tailscale_up_timeout | trim }}s"
+    tailscale_args_string: "{{ tailscale_args }} {{ tailscale_tags_string | trim if tailscale_tags_string is not none else '' }} --timeout={{ tailscale_up_timeout | trim }}s"
 
 - name: Install | Final `tailscale up` arguments string
   ansible.builtin.debug:


### PR DESCRIPTION
tailscale_tags_string templated to `None`, which is not a valid argument.

It would template to something like `"--login-server=https://ts.example.com None --timeout=120s"`, with `None` being an invalid argument causing the following error:
```
fatal: [host]: FAILED! => {"ansible_job_id": "j1.1", "changed": true, "cmd": ["tailscale", "up", "--login-server=https://ts.example.com", "None", "--timeout=120s", "--authkey=1234"], "delta": "0:00:00.004653", "end": "2024-09-19 12:59:36.991005", "finished": 1, "msg": "non-zero return code", "rc": 1, "results_file": "/root/.ansible_async/j1.1", "start": "2024-09-19 12:59:36.986352", "started": 1, "stderr": "too many non-flag arguments: [\"None\" \"--timeout=120s\" \"--auth-key=1234\"]", "stderr_lines": ["too many non-flag arguments: [\"None\" \"--timeout=120s\" \"--auth-key=1234\"]"], "stdout": "", "stdout_lines": []}
```

This seems to be an issue since v4.4.0.