### PR TITLE
refs#510: Patch tasks/debian/install.yml to manually wait for apt lock to be released

### DIFF
--- a/tasks/debian/install.yml
+++ b/tasks/debian/install.yml
@@ -26,7 +26,8 @@
 - name: Debian | Wait for apt to release lock
   become: true
   ansible.builtin.shell: "while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do sleep 1; done;"
-  changed_when: my_output.rc != 0 # <- Uses the return code to define when the task has changed.
+  register: shell_output
+  changed_when: shell_output.rc != 0 # <- Uses the return code to define when the task has changed.
 
 - name: Debian | Add Tailscale Deb
   become: true

--- a/tasks/debian/install.yml
+++ b/tasks/debian/install.yml
@@ -23,6 +23,11 @@
     dest: "{{ tailscale_apt_keyring_path }}"
     mode: '0644'
 
+- name: Debian | Wait for apt to release lock
+  become: true
+  ansible.builtin.shell: "while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do sleep 1; done;"
+  changed_when: my_output.rc != 0 # <- Uses the return code to define when the task has changed.
+
 - name: Debian | Add Tailscale Deb
   become: true
   ansible.builtin.apt_repository:


### PR DESCRIPTION
Closes #510 
Simple patch to allow tailscale role to succeed first time through on a new droplet.