### PR TITLE
fix: return faked response from up status check in check mode

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,6 +11,13 @@
     status: "{{ tailscale_status.stdout | from_json }}"
   ansible.builtin.set_fact:
     tailscale_is_online: "{{ status.Self.Online }}"
+  when: not ansible_check_mode
+
+- name: return faked response from JSON status check when in check mode
+  listen: Confirm Tailscale is Connected
+  ansible.builtin.set_fact:
+    tailscale_is_online: true
+  when: ansible_check_mode
 
 - name: Tailscale online status
   listen: Confirm Tailscale is Connected


### PR DESCRIPTION
Currently in check mode, the tailscale up status handler will fail out as it's trying to find a real status code for a faked out `$ tailscale up` command. This PR will return a true value when in check mode allowing Ansible's check mode to continue unabated. 